### PR TITLE
Button: ⌘/Ctrl+クリックで新規タブを開けるように

### DIFF
--- a/Button.svelte
+++ b/Button.svelte
@@ -30,7 +30,8 @@
     }
 
     if (href !== undefined) {
-      if (openNewTab) return window.open(href, '_blank')
+      // ⌘(Mac) / Ctrl(Windows) を押しながらのクリックは、ネイティブの <a> リンクと同様に新規タブで開く
+      if (openNewTab || event.metaKey || event.ctrlKey) return window.open(href, '_blank')
       if (isExternalUrl(href)) return (location.href = href)
       $goto(href)
     }


### PR DESCRIPTION
href指定のButtonは<button>+$goto()でプログラム遷移しているため、
ネイティブの<a href>のような「⌘/Ctrl+クリックで新規タブ」が効かなかった。
clickHandlerに修飾キー押下時はwindow.open(_blank)する分岐を追加。

- 通常クリック: 従来どおり同一タブのSPA遷移
- ⌘(Mac)/Ctrl(Windows)+クリック: 新規タブ
- 既存のopenNewTab=trueの挙動は不変

href付きButton全箇所(プラン/店舗/ラベル/セグメント等の編集ボタン)に一括で効く。

https://claude.ai/code/session_01Vn422DEn6sYDBmoacvYxVL

※このPRと関連するURLがあれば書いてください。  
例：Figma：https://www.figma.com/file/ikEv7n9NgsV8ScpDj5LuhC

### 作業内容

-

----------

### 作成・修正後

※このPRで作成・修正した部分のスクショや動画などを添付してください（リファクタリングなど見た目に変化がない場合は不要）
