### PR TITLE
[codex] Fix MultiSelect single option rendering

### DIFF
--- a/MultiSelect.svelte
+++ b/MultiSelect.svelte
@@ -108,7 +108,7 @@
           {/each}
         </div>
         <div>
-          {#each { length: values.length - 2 } as _, i}
+          {#each { length: Math.max(values.length - 2, 0) } as _, i}
             <div class="following-count">+{i + 1}</div>
           {/each}
         </div>


### PR DESCRIPTION
## Summary
- Clamp the hidden MultiSelect following-count placeholder length to zero or greater.

## Root Cause
When `values.length` was 0 or 1, the render-only width calculation used `{ length: values.length - 2 }`. For clients with exactly one label or coupon option, this created `{ length: -1 }`, which throws `RangeError: Invalid array length` during Svelte rendering and breaks the segment form.

## Impact
Segment delivery forms can render and remain interactive when any MultiSelect has fewer than two options, including clients with one label or one coupon.

## Checks
- `prettier --write MultiSelect.svelte`
- `git diff --check`
- Verified the placeholder count expression returns 0 for option counts 0, 1, and 2, and 1 for option count 3.