### PR TITLE
Modal: モーダル内で押下→外で離した時に閉じない様に

### DIFF
--- a/Modal.svelte
+++ b/Modal.svelte
@@ -25,8 +25,24 @@
     opened ? close() : open()
   }
 
-  function onClickBackdrop() {
-    if (!persistent) {
+  // バックドロップ上で mousedown が始まったかを記録するフラグ。
+  // click イベントは mousedown と mouseup の「共通祖先」で発火するため、
+  // フレーム内で押下 → バックドロップ上で離す（あるいはその逆のドラッグ）でも
+  // click はバックドロップ (.root) で発火してしまい、誤って閉じてしまう。
+  // それを防ぐため、押下と離上の両方がバックドロップ自身だったときだけ閉じる。
+  let backdropMouseDown = false
+
+  function onBackdropMouseDown(event: MouseEvent) {
+    // mousedown がバックドロップ (.root 自身) 上で始まったかだけを記録する。
+    backdropMouseDown = event.target === event.currentTarget
+  }
+
+  function onBackdropMouseUp(event: MouseEvent) {
+    // mousedown も mouseup もバックドロップ自身のときだけ閉じる。
+    // (内側 mousedown → 外側 mouseup / 外側 mousedown → 内側 mouseup はいずれも閉じない)
+    const shouldClose = backdropMouseDown && event.target === event.currentTarget
+    backdropMouseDown = false
+    if (shouldClose && !persistent) {
       close()
     }
   }
@@ -35,7 +51,13 @@
 <slot name="launcher" {open} {close} {toggle} />
 {#if opened}
   <Portal>
-    <div class="root" transition:fade={{ duration: 150 }} on:click|self={onClickBackdrop} {...$$restProps}>
+    <div
+      class="root"
+      transition:fade={{ duration: 150 }}
+      on:mousedown={onBackdropMouseDown}
+      on:mouseup={onBackdropMouseUp}
+      {...$$restProps}
+    >
       <slot name="frame" {open} {close} {toggle}>
         <div class={`frame ${klass}`} {style}>
           <div class="flex items-center justify-between py-1.5" class:hidden={!$$slots.title && !showCloseButton}>


### PR DESCRIPTION
### 作業内容

編集・確認系のダイアログモーダルで、**モーダル内で mousedown → モーダル外（バックドロップ）で mouseup** したときに、意図せずモーダルが閉じてしまう不具合を修正しました。

#### 再現していた問題
- モーダルの外を明確にクリック（押下も離上も外）→ 閉じる（これは正しい挙動、変更なし）
- モーダル**内**で押下 → そのまま**外**で離す（例: 入力欄のテキストを範囲選択してドラッグが枠外まで及ぶ）→ **閉じてしまっていた**（これが不具合）

#### 原因
バックドロップの dismiss 判定を `on:click|self` で行っていたため。`click` イベントは mousedown と mouseup の **共通祖先** で発火するので、フレーム内で押下してバックドロップ上で離すと `click` が `.root`（バックドロップ）で発火し、`|self` を通過して `close()` が呼ばれていました。

#### 修正
`on:click|self` をやめ、`on:mousedown` / `on:mouseup` を併用。**押下と離上の両方がバックドロップ自身**（`event.target === event.currentTarget`）だったときだけ閉じるようにしました。

| 操作 | 修正前 | 修正後 |
| --- | --- | --- |
| バックドロップ押下 → バックドロップ離上 | 閉じる | 閉じる（変更なし） |
| フレーム内で押下 → バックドロップで離上 | **閉じる(不具合)** | **閉じない** |
| バックドロップで押下 → フレーム内で離上 | **閉じる** | **閉じない**（逆ドラッグも誤爆させない） |
| `persistent` 指定時 | 閉じない | 閉じない（変更なし） |

同様の対策は本体リポジトリ（on-Line-Subscribe）の `RichMenuEditor` のオーバーレイにも既に入っており、その実装に揃えています。

#### 確認した内容（本体リポジトリの CI 相当）
- `prettier --check`（shared-components の `.prettierrc.yml`）: OK
- `svelte-check`（validate / `--fail-on-warnings --fail-on-hints`）: 0 errors / 0 warnings / 0 hints
- `tsc`（typecheck）: OK
- `eslint`（対象ファイル）: OK
- a11y: `a11y-mouse-events-have-key-events` は `mouseover` / `mouseout` のみが対象で `mousedown` / `mouseup` は対象外。新規警告なし。

----------

### 作成・修正後

挙動修正のため見た目の変化はありません（スクショ省略）。
