### PR TITLE
fix(dark): コンポーネントの色直値をCSS変数化しダークモードのコントラストを改善

### DIFF
--- a/AutoSizeTextArea.svelte
+++ b/AutoSizeTextArea.svelte
@@ -82,7 +82,7 @@
     resize: none;
 
     .disabled & {
-      background-color: hsla(0, 0%, 0%, 4%);
+      background-color: var(--surface_bg_disabled);
     }
   }
 

--- a/Button.svelte
+++ b/Button.svelte
@@ -107,19 +107,19 @@
 
         @media (hover: hover) {
           &:hover {
-            background-color: hsl(0, 0%, 82%);
+            background-color: var(--neutral_bg_hover);
             transition-duration: 0s;
           }
         }
 
         &:active {
-          background-color: hsl(0, 0%, 78%);
+          background-color: var(--neutral_bg_active);
           transition-duration: 0s;
         }
 
         &.disabled {
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
 
@@ -185,8 +185,8 @@
 
         &.disabled {
           border: none;
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
 
@@ -208,8 +208,8 @@
 
         &.disabled {
           border: none;
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
 
@@ -231,8 +231,8 @@
 
         &.disabled {
           border: none;
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
 
@@ -254,14 +254,14 @@
 
         &.disabled {
           border: none;
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
     }
 
     &[data-variant='outline'] {
-      background-color: white;
+      background-color: var(--surface_bg);
 
       &[data-color='primary'] {
         border: var(--main_color) 1px solid;
@@ -269,7 +269,7 @@
 
         @media (hover: hover) {
           &:hover {
-            background-color: hsl(0, 0%, 97%);
+            background-color: var(--surface_bg_hover);
             transition-duration: 0s;
           }
         }
@@ -281,8 +281,8 @@
 
         &.disabled {
           border: none;
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
 
@@ -292,20 +292,20 @@
 
         @media (hover: hover) {
           &:hover {
-            background-color: hsl(0, 0%, 97%);
+            background-color: var(--surface_bg_hover);
             transition-duration: 0s;
           }
         }
 
         &:active {
-          background-color: hsl(0, 0%, 94%);
+          background-color: var(--surface_bg_active);
           transition-duration: 0s;
         }
 
         &.disabled {
           border: none;
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
 
@@ -315,20 +315,20 @@
 
         @media (hover: hover) {
           &:hover {
-            background-color: hsl(0, 0%, 97%);
+            background-color: var(--surface_bg_hover);
             transition-duration: 0s;
           }
         }
 
         &:active {
-          background-color: hsl(0, 0%, 94%);
+          background-color: var(--surface_bg_active);
           transition-duration: 0s;
         }
 
         &.disabled {
           border: none;
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
 
@@ -338,7 +338,7 @@
 
         @media (hover: hover) {
           &:hover {
-            background-color: hsl(0, 0%, 97%);
+            background-color: var(--surface_bg_hover);
             transition-duration: 0s;
           }
         }
@@ -350,8 +350,8 @@
 
         &.disabled {
           border: none;
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
     }
@@ -373,8 +373,8 @@
         }
 
         &.disabled {
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
 
@@ -394,8 +394,8 @@
         }
 
         &.disabled {
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
 
@@ -415,8 +415,8 @@
         }
 
         &.disabled {
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
 
@@ -436,8 +436,8 @@
         }
 
         &.disabled {
-          background-color: hsl(0, 0%, 96%);
-          color: hsl(0, 0%, 75%);
+          background-color: var(--surface_bg_disabled);
+          color: var(--text_disabled);
         }
       }
     }

--- a/Checkbox.svelte
+++ b/Checkbox.svelte
@@ -67,7 +67,7 @@
     &.disabled {
       cursor: default;
 
-      color: hsl(0 0% 70%);
+      color: var(--text_disabled);
     }
   }
 
@@ -83,8 +83,8 @@
     height: var(--size);
     border-radius: 0.25em;
     margin: 0;
-    border: 1px solid hsl(0 0% 84%);
-    background-color: white;
+    border: 1px solid var(--line_color_gray);
+    background-color: var(--surface_bg);
 
     cursor: pointer;
 
@@ -95,7 +95,7 @@
       border: none;
 
       .disabled & {
-        background-color: hsl(0 0% 90%);
+        background-color: var(--bg_color_sub1);
       }
     }
 

--- a/CommonCss.svelte
+++ b/CommonCss.svelte
@@ -25,8 +25,55 @@
     --liff_bg_gray: hsl(0, 0%, 93%);
     --liff_bg_black: hsl(0, 0%, 81%);
 
+    /* === コンポーネントの面色・状態色 ===
+     * 以前は各コンポーネントの <style> 内に white / hsl(0 0% 9x%) などを直値で
+     * 持っていたため、ダークモード(data-color-mode='dark')でも白い面・薄グレーの
+     * まま残りコントラストが破綻していた。共通変数化し、ライト既定値は従来の直値と
+     * 一致させている(ライト表示は不変)。ダーク値は下の dark ブロックで上書きする。 */
+    --surface_bg: hsl(0, 0%, 100%); /* 入力欄・ドロップダウン・モーダル等の白い面 */
+    --surface_bg_hover: hsl(0, 0%, 97%); /* 面上のホバー(薄グレー) */
+    --surface_bg_active: hsl(0, 0%, 94%); /* 面上のアクティブ/押下 */
+    --surface_bg_disabled: hsl(0, 0%, 96%); /* disabled の面 */
+    --neutral_bg_hover: hsl(0, 0%, 82%); /* グレー(achromatic)ボタンのホバー */
+    --neutral_bg_active: hsl(0, 0%, 78%); /* グレー(achromatic)ボタンの押下 */
+    --text_disabled: hsl(0, 0%, 75%); /* disabled の文字 */
+    --selected_bg: hsl(187, 60%, 95%); /* 選択中 option の地(メインカラーの淡色) */
+    --selected_bg_hover: hsl(187, 60%, 93%);
+    --selected_bg_active: hsl(187, 60%, 91%);
+
     /* 複数のコンポーネントで共有する変数 */
     --one-line-input-height: 2.5em;
     --modal-backdrop-z-index: 1000;
+  }
+
+  /**
+   * ダークモード。プロジェクト側(on-Line-Subscribe の app.postcss)は同じ変数を
+   * より高い詳細度で上書きするためそちらが優先されるが、submodule 単体・カタログ
+   * でもダークが成立するよう :where で低詳細度のフォールバック値を持たせる。
+   * 既存パレットの値はプロジェクト側 dark 定義と一致させている。
+   */
+  :where(:root[data-color-mode='dark']) {
+    --main_color: hsl(187, 62%, 54%);
+    --secondary_color: hsl(89, 45%, 62%);
+    --tt_color_black: hsl(190, 24%, 92%);
+    --tt_color_gray: hsl(190, 13%, 76%);
+    --tt_color_light-gray: hsl(190, 10%, 62%);
+    --line_color_black: hsl(190, 12%, 78%);
+    --line_color_gray: hsl(190, 10%, 42%);
+    --bg_color_main: hsl(220, 19%, 12%);
+    --bg_color_sub1: hsl(220, 17%, 17%);
+    --bg_color_sub2: hsl(220, 15%, 21%);
+    --attention_color: hsl(358, 84%, 68%);
+
+    --surface_bg: hsl(220, 15%, 21%);
+    --surface_bg_hover: hsl(220, 14%, 26%);
+    --surface_bg_active: hsl(220, 13%, 31%);
+    --surface_bg_disabled: hsl(220, 16%, 16%);
+    --neutral_bg_hover: hsl(220, 12%, 30%);
+    --neutral_bg_active: hsl(220, 12%, 36%);
+    --text_disabled: hsl(220, 8%, 50%);
+    --selected_bg: hsl(187, 36%, 24%);
+    --selected_bg_hover: hsl(187, 36%, 28%);
+    --selected_bg_active: hsl(187, 36%, 32%);
   }
 </style>

--- a/DataTable.svelte
+++ b/DataTable.svelte
@@ -362,12 +362,12 @@
 
     @media (hover: hover) {
       .row-clickable .body-row:hover & {
-        background-color: hsl(0 0% 97%);
+        background-color: var(--surface_bg_hover);
       }
     }
 
     .row-clickable .body-row:active & {
-      background-color: hsl(0 0% 95%);
+      background-color: var(--surface_bg_active);
     }
   }
 

--- a/DateInput.svelte
+++ b/DateInput.svelte
@@ -84,7 +84,8 @@
 
 <style lang="postcss">
   .root {
-    @apply w-full rounded-md grid items-center bg-white text-start;
+    @apply w-full rounded-md grid items-center text-start;
+    background-color: var(--surface_bg);
     grid-template-columns: 1fr auto;
     min-height: var(--one-line-input-height);
     padding: 0.4em 0.7em;
@@ -93,7 +94,7 @@
 
     &:disabled {
       @apply cursor-default;
-      background-color: hsla(0, 0%, 0%, 4%);
+      background-color: var(--surface_bg_disabled);
     }
   }
 

--- a/DatePicker.svelte
+++ b/DatePicker.svelte
@@ -118,7 +118,7 @@
     font-size: 18px;
 
     .day-row & {
-      color: hsl(0 0% 50%);
+      color: var(--tt_color_gray);
 
       &[data-day='0'] {
         color: hsl(5 35% 50%);
@@ -132,17 +132,17 @@
     .date-row & {
       @media (hover: hover) {
         &:hover {
-          background-color: hsl(0 0% 96%);
+          background-color: var(--surface_bg_hover);
         }
       }
 
       &:active {
-        background-color: hsl(0 0% 92%);
+        background-color: var(--surface_bg_active);
       }
 
       &.next-month,
       &.prev-month {
-        color: hsl(0 0% 60%);
+        color: var(--tt_color_light-gray);
       }
 
       &.selected {
@@ -151,7 +151,7 @@
       }
 
       &:disabled {
-        color: hsl(0 0% 85%);
+        color: var(--text_disabled);
       }
     }
   }

--- a/FarDateInput.svelte
+++ b/FarDateInput.svelte
@@ -58,7 +58,8 @@
 
 <style lang="postcss">
   .root {
-    @apply w-full rounded-md flex items-center justify-between bg-white;
+    @apply w-full rounded-md flex items-center justify-between;
+    background-color: var(--surface_bg);
     height: var(--one-line-input-height);
     padding: 0 0.7em;
     border: var(--tt_color_light-gray) 1px solid;
@@ -66,7 +67,7 @@
 
     &.disabled {
       @apply cursor-default;
-      background-color: hsla(0, 0%, 0%, 4%);
+      background-color: var(--surface_bg_disabled);
     }
   }
 

--- a/FarDatePicker.svelte
+++ b/FarDatePicker.svelte
@@ -52,7 +52,7 @@
 
   .title {
     text-align: center;
-    color: hsl(0 0% 40%);
+    color: var(--tt_color_gray);
     font-size: 16px;
     margin: 0.7em;
   }

--- a/Foldable.svelte
+++ b/Foldable.svelte
@@ -85,7 +85,7 @@
 
 <style lang="postcss">
   .root {
-    background-color: hsl(0 0% 96%);
+    background-color: var(--bg_color_sub2);
     border-radius: 0.5rem;
   }
 

--- a/Modal.svelte
+++ b/Modal.svelte
@@ -104,7 +104,8 @@
   }
 
   .frame {
-    @apply grid bg-white;
+    @apply grid;
+    background-color: var(--surface_bg);
     grid-template-rows: auto auto minmax(0, 1fr) auto auto;
     max-height: 90vh;
     max-width: 90vw;

--- a/MultiSelect.svelte
+++ b/MultiSelect.svelte
@@ -176,7 +176,7 @@
     box-sizing: border-box;
     min-height: var(--one-line-input-height);
 
-    background-color: white;
+    background-color: var(--surface_bg);
     font: inherit;
     cursor: pointer;
 
@@ -185,7 +185,7 @@
     }
 
     &.disabled {
-      background-color: hsla(0, 0%, 0%, 4%);
+      background-color: var(--surface_bg_disabled);
       cursor: initial;
     }
 
@@ -212,8 +212,8 @@
   .following-count {
     border-radius: 99999px;
     padding: 0.2em 0.5em;
-    background-color: hsl(0 0% 94%);
-    color: hsl(0 0 30%);
+    background-color: var(--surface_bg_active);
+    color: var(--tt_color_black);
     font-size: 80%;
   }
 
@@ -250,7 +250,7 @@
     width: var(--dropdown-width);
     max-height: var(--dropdown-man-height);
     border-radius: 0.4em;
-    background-color: white;
+    background-color: var(--surface_bg);
     box-shadow: 0 3px 14px hsla(0, 0%, 0%, 20%);
 
     overflow: auto;

--- a/Popover.svelte
+++ b/Popover.svelte
@@ -173,7 +173,8 @@
   }
 
   .frame {
-    @apply fixed grid bg-white rounded-lg;
+    @apply fixed grid rounded-lg;
+    background-color: var(--surface_bg);
     transform: var(--transform);
     box-shadow: 0 3px 14px hsla(0, 0%, 0%, 20%);
 

--- a/RadioButtons.svelte
+++ b/RadioButtons.svelte
@@ -96,7 +96,7 @@
 
     &.disabled {
       cursor: default;
-      color: hsl(0 0% 70%);
+      color: var(--text_disabled);
     }
   }
 
@@ -114,8 +114,8 @@
     border-radius: 100%;
     margin: 0;
 
-    border: hsl(0 0% 60%) 1px solid;
-    background-color: white;
+    border: var(--line_color_black) 1px solid;
+    background-color: var(--surface_bg);
 
     cursor: pointer;
 
@@ -126,7 +126,7 @@
       border-color: var(--main_color);
 
       .disabled & {
-        border-color: hsl(0 0% 70%);
+        border-color: var(--line_color_gray);
       }
     }
 
@@ -154,7 +154,7 @@
       transition: all 0.1s ease-out;
 
       .disabled & {
-        background-color: hsl(0 0% 70%);
+        background-color: var(--tt_color_light-gray);
       }
     }
   }

--- a/Select.svelte
+++ b/Select.svelte
@@ -199,7 +199,7 @@
     box-sizing: border-box;
     min-height: var(--one-line-input-height);
 
-    background-color: white;
+    background-color: var(--surface_bg);
     font: inherit;
     cursor: pointer;
 
@@ -208,7 +208,7 @@
     }
 
     &.disabled {
-      background-color: hsla(0, 0%, 0%, 4%);
+      background-color: var(--surface_bg_disabled);
       cursor: initial;
     }
 
@@ -260,7 +260,7 @@
     width: var(--dropdown-width);
     max-height: var(--dropdown-man-height);
     border-radius: 0.4em;
-    background-color: white;
+    background-color: var(--surface_bg);
     box-shadow: 0 3px 14px hsla(0, 0%, 0%, 20%);
 
     overflow: auto;
@@ -282,32 +282,32 @@
     box-sizing: border-box;
     width: 100%;
 
-    background-color: white;
+    background-color: var(--surface_bg);
     font: inherit;
     cursor: pointer;
 
     @media (hover: hover) {
       &:hover {
-        background-color: hsl(0 0% 97%);
+        background-color: var(--surface_bg_hover);
       }
     }
 
     &:active {
-      background-color: hsl(0 0% 94%);
+      background-color: var(--surface_bg_active);
     }
 
     &.selected {
-      background-color: hsl(187, 60%, 95%);
+      background-color: var(--selected_bg);
       color: var(--main_color);
 
       @media (hover: hover) {
         &:hover {
-          background-color: hsl(187, 60%, 93%);
+          background-color: var(--selected_bg_hover);
         }
       }
 
       &:active {
-        background-color: hsl(187, 60%, 91%);
+        background-color: var(--selected_bg_active);
       }
     }
   }

--- a/SortButton.svelte
+++ b/SortButton.svelte
@@ -22,14 +22,14 @@
     transform-origin: center;
     transition: all 140ms ease-out;
     transform: rotate(0deg);
-    color: hsl(0 0% 50%);
+    color: var(--tt_color_gray);
 
     &.reversed {
       transform: rotate(-180deg);
     }
 
     &.sorted {
-      color: hsl(0 0% 0%);
+      color: var(--tt_color_black);
     }
   }
 </style>

--- a/Tabs.svelte
+++ b/Tabs.svelte
@@ -58,13 +58,14 @@
 
   .tab {
     @apply px-[30px] h-10 rounded-t-lg flex items-center text-sm cursor-pointer;
-    border: 1px solid hsl(0, 0%, 90%);
+    border: 1px solid var(--line_color_gray);
     border-bottom: none;
     background-color: var(--bg_color_sub2);
     color: var(--tt_color_gray);
 
     &.selected {
-      @apply bg-white font-bold border-none;
+      @apply font-bold border-none;
+      background-color: var(--surface_bg);
       color: var(--tt_color_black);
     }
   }
@@ -75,7 +76,8 @@
   }
 
   .content-area {
-    @apply bg-white pointer-events-auto;
+    @apply pointer-events-auto;
+    background-color: var(--surface_bg);
     border-radius: 0 0.5rem 0.5rem 0.5rem;
   }
 </style>

--- a/TextInput.svelte
+++ b/TextInput.svelte
@@ -122,7 +122,8 @@
 
 <style lang="postcss">
   .root {
-    @apply w-full block rounded-md bg-white;
+    @apply w-full block rounded-md;
+    background-color: var(--surface_bg);
     height: var(--one-line-input-height);
     padding: 0 0.7em;
     border: var(--tt_color_light-gray) 1px solid;
@@ -133,7 +134,7 @@
     }
 
     &.disabled {
-      background-color: hsla(0, 0%, 0%, 4%);
+      background-color: var(--surface_bg_disabled);
     }
   }
 

--- a/YearPicker.svelte
+++ b/YearPicker.svelte
@@ -63,7 +63,7 @@
 
     & :global(.foldable) {
       border-radius: 0;
-      background-color: hsl(0 0% 100%);
+      background-color: var(--surface_bg);
       border: var(--line_color_gray) 1px solid;
 
       &:not(:first-of-type) {
@@ -83,7 +83,7 @@
     gap: 0.5em;
     padding: 1em 0.5em;
 
-    background-color: hsl(0 0% 100%);
+    background-color: var(--surface_bg);
     font-size: 14px;
   }
 </style>


### PR DESCRIPTION
## 背景 / 問題
サブスクライン管理画面のダークモードで、shared-components 由来の UI に次の見え方の崩れが出ていた。

- 濃いグレーの背景に黒い文字が乗ってコントラストが低い
- ダークなのに白いまま残る UI パーツ（入力欄・ドロップダウン・モーダル・チェックボックス・タブ等）

## 原因
各コンポーネントの `<style>` 内で背景・文字・境界の色を `white` / `hsl(0 0% 9x%)` などの**直値でハードコード**していた。Svelte の scoped style は固有クラス（`.s-xxxx`）へコンパイルされるため、利用側（on-Line-Subscribe）が `app.postcss` で行っているダーク用ユーティリティ remap（`.bg-white` 等）が**ほぼ届かず**、ダークでも明色のまま取り残されていた。利用側で個々の内部クラス名を追いかけて remap する現状は脆く、新規コンポーネントや拾い漏れで再発する。→ **コンポーネント側で恒久対応**する。

## 対応
- `CommonCss.svelte` に面色・状態色のセマンティック変数を新設
  - `--surface_bg` / `--surface_bg_hover` / `--surface_bg_active` / `--surface_bg_disabled`
  - `--neutral_bg_hover` / `--neutral_bg_active`（グレーボタン用）
  - `--text_disabled`
  - `--selected_bg` / `--selected_bg_hover` / `--selected_bg_active`（選択 option）
  - **ライト既定値は従来の直値と一致**させており、ライトモードの見た目は不変。
- `:where(:root[data-color-mode='dark'])` でダーク値を定義。既存パレット（`--bg_color_*` / `--tt_color_*` / `--line_color_*` / `--main_color` 等）のダーク値も利用側 `app.postcss` と同値で内包し、`:where` で低詳細度にして利用側からの上書きを許容（既存の二重管理方針に準拠。submodule 単体・カタログでもダークが成立する）。
- 各コンポーネントの中立色の直値を上記変数参照へ置換。
  - Button / Select / MultiSelect / TextInput / AutoSizeTextArea / Modal / Popover / Checkbox / RadioButtons / Tabs / Foldable / DataTable / DatePicker / DateInput / FarDateInput / FarDatePicker / YearPicker / SortButton
  - あわせて `MultiSelect` の不正値 `color: hsl(0 0 30%)`（単位欠落でブラウザが無視）を解消。

## 意図的に変更していない箇所
- ブランド色の塗り（ティール / 緑 / 赤）
- モーダル暗幕などの半透明オーバーレイ、`box-shadow`
- ブランド地の上に乗る白文字
- `Checkbox` の `::before`（チェックマークの白）
- `Spinner` の mask 用 `stroke`（実色は `--color`）
- 曜日色、SVG アイコンの `tint`

## 影響範囲
- **CSS のみ**の変更。props・API・挙動は不変（カタログ更新不要）。
- **ライトモードの見た目は不変**（変数のライト既定値＝従来の直値）。
- backend / migration への波及なし。

## 検証
- 編集ファイル全件 `prettier --check` 済（既存スタイル準拠）。
- 利用側で参照される CSS 変数が全て `CommonCss.svelte` に定義済みであることを確認。
- ダークの直値残存ゼロ（保持対象=オーバーレイ・影・チェックマーク白・曜日色・アイコン tint のみ）。

> 利用側（on-Line-Subscribe）への反映は本 PR マージ後に `git submodule update --remote` でピン更新が必要。